### PR TITLE
[PR] - Adiciona envio e-mail de confirmação de cadastro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
 			<version>5.5.5</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.mailtrap</groupId>
+			<artifactId>mailtrap-java</artifactId>
+			<version>1.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/domain/exception/UsuarioNaoEncontradoException.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/domain/exception/UsuarioNaoEncontradoException.java
@@ -1,0 +1,9 @@
+package br.com.fatec.mogi.inventory_auth_service.domain.exception;
+
+public class UsuarioNaoEncontradoException extends IllegalArgumentException {
+
+	public UsuarioNaoEncontradoException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/domain/model/Usuario.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/domain/model/Usuario.java
@@ -27,6 +27,8 @@ public class Usuario {
 	@Embedded
 	private Email email;
 
+	private boolean ativo;
+
 	private LocalDateTime dataCriacao;
 
 	private LocalDateTime dataAlteracao;

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/service/EmailService.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/service/EmailService.java
@@ -1,0 +1,9 @@
+package br.com.fatec.mogi.inventory_auth_service.service;
+
+import br.com.fatec.mogi.inventory_auth_service.domain.model.Usuario;
+
+public interface EmailService {
+
+	boolean enviarEmailConfirmacao(Usuario usuario);
+
+}

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/service/UsuarioService.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/service/UsuarioService.java
@@ -2,9 +2,12 @@ package br.com.fatec.mogi.inventory_auth_service.service;
 
 import br.com.fatec.mogi.inventory_auth_service.domain.model.Usuario;
 import br.com.fatec.mogi.inventory_auth_service.web.dto.request.CadastrarUsuarioRequestDTO;
+import br.com.fatec.mogi.inventory_auth_service.web.dto.request.ConfirmarCadastroUsuarioRequestDTO;
 
 public interface UsuarioService {
 
 	Usuario cadastrarUsuario(CadastrarUsuarioRequestDTO dto);
+
+	boolean confirmarCadastro(ConfirmarCadastroUsuarioRequestDTO dto);
 
 }

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/service/impl/EmailServiceImpl.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/service/impl/EmailServiceImpl.java
@@ -1,0 +1,63 @@
+package br.com.fatec.mogi.inventory_auth_service.service.impl;
+
+import br.com.fatec.mogi.inventory_auth_service.domain.model.Usuario;
+import br.com.fatec.mogi.inventory_auth_service.service.EmailService;
+import io.mailtrap.client.MailtrapClient;
+import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.emails.Address;
+import io.mailtrap.model.request.emails.MailtrapMail;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Profile("!test")
+public class EmailServiceImpl implements EmailService {
+
+	@Value("${mail-trap-token}")
+	private String apiToken;
+
+	@Value("${auth-email-sender}")
+	private String emailSender;
+
+	@Value("${confirm-email-code-url}")
+	private String confirmUrl;
+
+	@Value("${confirm-template-id}")
+	private String confirmTemplateId;
+
+	@Value("${confirm-code-ttl:300}")
+	private String confirmTtl;
+
+	private MailtrapClient mailtrapClient;
+
+	@PostConstruct
+	void postConstruct() {
+		MailtrapConfig mailtrapConfig = new MailtrapConfig.Builder().token(apiToken).build();
+		mailtrapClient = MailtrapClientFactory.createMailtrapClient(mailtrapConfig);
+	}
+
+	@Override
+	public boolean enviarEmailConfirmacao(Usuario usuario) {
+		try {
+			MailtrapMail mail = MailtrapMail.builder()
+					.from(new Address(emailSender, "Confirmação e-mail"))
+					.to(List.of(new Address(usuario.getEmail().getEmail())))
+					.templateUuid(confirmTemplateId)
+					.templateVariables(Map.of("name", usuario.getNome(), "url", confirmUrl))
+					.build();
+			var response = mailtrapClient.send(mail);
+			return response.isSuccess();
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+}

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/service/impl/UsuarioServiceImpl.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/service/impl/UsuarioServiceImpl.java
@@ -2,14 +2,18 @@ package br.com.fatec.mogi.inventory_auth_service.service.impl;
 
 import br.com.fatec.mogi.inventory_auth_service.domain.exception.EmailJaUtilizadoException;
 import br.com.fatec.mogi.inventory_auth_service.domain.exception.FuncaoNaoEncontrada;
+import br.com.fatec.mogi.inventory_auth_service.domain.exception.UsuarioNaoEncontradoException;
 import br.com.fatec.mogi.inventory_auth_service.domain.model.Funcao;
 import br.com.fatec.mogi.inventory_auth_service.domain.model.Usuario;
 import br.com.fatec.mogi.inventory_auth_service.domain.model.UsuarioFuncao;
+import br.com.fatec.mogi.inventory_auth_service.domain.model.valueObjects.Email;
 import br.com.fatec.mogi.inventory_auth_service.repository.FuncaoRepository;
 import br.com.fatec.mogi.inventory_auth_service.repository.UsuarioFuncaoRepository;
 import br.com.fatec.mogi.inventory_auth_service.repository.UsuarioRepository;
+import br.com.fatec.mogi.inventory_auth_service.service.EmailService;
 import br.com.fatec.mogi.inventory_auth_service.service.UsuarioService;
 import br.com.fatec.mogi.inventory_auth_service.web.dto.request.CadastrarUsuarioRequestDTO;
+import br.com.fatec.mogi.inventory_auth_service.web.dto.request.ConfirmarCadastroUsuarioRequestDTO;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,8 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UsuarioServiceImpl implements UsuarioService {
+
+	private final EmailService emailService;
 
 	private final UsuarioRepository usuarioRepository;
 
@@ -33,9 +39,21 @@ public class UsuarioServiceImpl implements UsuarioService {
 		usuarioRepository.findByEmail(usuario.getEmail()).ifPresent(u -> {
 			throw new EmailJaUtilizadoException("E-mail já utilizado.");
 		});
+		var emailEnviado = emailService.enviarEmailConfirmacao(usuario);
+		usuario.setAtivo(!emailEnviado);
 		Usuario usuarioSalvo = usuarioRepository.save(usuario);
 		usuarioFuncaoRepository.save(new UsuarioFuncao(usuarioSalvo, funcao));
 		return usuarioSalvo;
+	}
+
+	@Override
+	@Transactional
+	public boolean confirmarCadastro(ConfirmarCadastroUsuarioRequestDTO dto) {
+		var usuario = usuarioRepository.findByEmail(new Email(dto.getEmail()))
+			.orElseThrow(() -> new UsuarioNaoEncontradoException("Usuário não encontrado."));
+		usuario.setAtivo(true);
+		usuarioRepository.save(usuario);
+		return true;
 	}
 
 }

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/web/UsuarioController.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/web/UsuarioController.java
@@ -1,23 +1,34 @@
 package br.com.fatec.mogi.inventory_auth_service.web;
 
-import br.com.fatec.mogi.inventory_auth_service.domain.model.Usuario;
 import br.com.fatec.mogi.inventory_auth_service.service.UsuarioService;
 import br.com.fatec.mogi.inventory_auth_service.web.dto.request.CadastrarUsuarioRequestDTO;
+import br.com.fatec.mogi.inventory_auth_service.web.dto.request.ConfirmarCadastroUsuarioRequestDTO;
+import br.com.fatec.mogi.inventory_auth_service.web.dto.response.CadastrarUsuarioResponseDTO;
+import br.com.fatec.mogi.inventory_auth_service.web.dto.response.ConfirmarCadastroUsuarioResponseDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth-service/v1/usuarios")
 public record UsuarioController(UsuarioService usuarioService) {
 
 	@PostMapping
-	public ResponseEntity<Usuario> cadastrarUsuario(@RequestBody CadastrarUsuarioRequestDTO dto) {
+	public ResponseEntity<CadastrarUsuarioResponseDTO> cadastrarUsuario(@RequestBody CadastrarUsuarioRequestDTO dto) {
 		var usuario = usuarioService.cadastrarUsuario(dto);
-		return ResponseEntity.status(HttpStatus.CREATED).body(usuario);
+		CadastrarUsuarioResponseDTO responseDTO = CadastrarUsuarioResponseDTO.builder()
+			.email(usuario.getEmail().getEmail())
+			.nome(usuario.getNome())
+			.build();
+		return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+	}
+
+	@PutMapping("/confirmar-cadastro")
+	public ResponseEntity<ConfirmarCadastroUsuarioResponseDTO> confirmarCadastro(
+			@RequestBody ConfirmarCadastroUsuarioRequestDTO dto) {
+		var confirmado = usuarioService.confirmarCadastro(dto);
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(new ConfirmarCadastroUsuarioResponseDTO(confirmado));
 	}
 
 }

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/web/dto/request/ConfirmarCadastroUsuarioRequestDTO.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/web/dto/request/ConfirmarCadastroUsuarioRequestDTO.java
@@ -1,0 +1,16 @@
+package br.com.fatec.mogi.inventory_auth_service.web.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfirmarCadastroUsuarioRequestDTO {
+
+	private String email;
+
+}

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/web/dto/response/CadastrarUsuarioResponseDTO.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/web/dto/response/CadastrarUsuarioResponseDTO.java
@@ -1,0 +1,18 @@
+package br.com.fatec.mogi.inventory_auth_service.web.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CadastrarUsuarioResponseDTO {
+
+	private String nome;
+
+	private String email;
+
+}

--- a/src/main/java/br/com/fatec/mogi/inventory_auth_service/web/dto/response/ConfirmarCadastroUsuarioResponseDTO.java
+++ b/src/main/java/br/com/fatec/mogi/inventory_auth_service/web/dto/response/ConfirmarCadastroUsuarioResponseDTO.java
@@ -1,0 +1,16 @@
+package br.com.fatec.mogi.inventory_auth_service.web.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfirmarCadastroUsuarioResponseDTO {
+
+	private boolean confirmado;
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=inventory-auth-service
+
+# E-mail sender configuration
+auth-email-sender=confirmacao@sistema.inventario.fatecmc.com
+mail-trap-token=197c503813de85bc1d61732261dc22e8
+confirm-email-code-url=www.google.com
+confirm-template-id=4b58e1c5-58d2-4d04-84d2-0a9d8fabda85

--- a/src/test/java/br/com/fatec/mogi/inventory_auth_service/service/EmailServiceTest.java
+++ b/src/test/java/br/com/fatec/mogi/inventory_auth_service/service/EmailServiceTest.java
@@ -1,0 +1,27 @@
+package br.com.fatec.mogi.inventory_auth_service.service;
+
+import br.com.fatec.mogi.inventory_auth_service.domain.model.Usuario;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("integration")
+public class EmailServiceTest {
+
+	@Autowired
+	private EmailService emailService;
+
+	@Test
+	@DisplayName("Deve enviar e-mail de confirmação com sucesso")
+	void deveEnviarEmailConfirmacaoComSucesso() {
+		Usuario usuario = new Usuario("Rodrigo", "Senha123", "gernohovskirodrigo@gmail.com");
+		var enviado = emailService.enviarEmailConfirmacao(usuario);
+		assertTrue(enviado);
+	}
+
+}

--- a/src/test/java/br/com/fatec/mogi/inventory_auth_service/service/fake/EmailServiceFake.java
+++ b/src/test/java/br/com/fatec/mogi/inventory_auth_service/service/fake/EmailServiceFake.java
@@ -1,0 +1,23 @@
+package br.com.fatec.mogi.inventory_auth_service.service.fake;
+
+import br.com.fatec.mogi.inventory_auth_service.domain.model.Usuario;
+import br.com.fatec.mogi.inventory_auth_service.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Profile("test")
+public class EmailServiceFake implements EmailService {
+
+    @Override
+    public boolean enviarEmailConfirmacao(Usuario usuario) {
+        if (usuario.getEmail().getEmail().equals("emailinvalido@gmail.com")) {
+            return false;
+        }
+        String emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
+        return usuario.getEmail().getEmail().matches(emailRegex);
+    }
+
+}

--- a/src/test/java/br/com/fatec/mogi/inventory_auth_service/web/UsuarioControllerTest.java
+++ b/src/test/java/br/com/fatec/mogi/inventory_auth_service/web/UsuarioControllerTest.java
@@ -1,6 +1,8 @@
 package br.com.fatec.mogi.inventory_auth_service.web;
 
 import br.com.fatec.mogi.inventory_auth_service.web.dto.request.CadastrarUsuarioRequestDTO;
+import br.com.fatec.mogi.inventory_auth_service.web.dto.request.ConfirmarCadastroUsuarioRequestDTO;
+import br.com.fatec.mogi.inventory_auth_service.web.dto.response.ConfirmarCadastroUsuarioResponseDTO;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
@@ -9,10 +11,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles("integration")
 public class UsuarioControllerTest {
 
 	@LocalServerPort
@@ -105,6 +107,68 @@ public class UsuarioControllerTest {
 			.asString();
 
 		assertEquals("E-mail já utilizado.", errorMessage);
+	}
+
+	@Test
+	@DisplayName("Deve confirmar o cadastro de um usuário com sucesso")
+	void deveConfirmarCadastroUsuarioComSucesso() {
+		CadastrarUsuarioRequestDTO cadastrarUsuarioRequestDTO = CadastrarUsuarioRequestDTO.builder()
+				.nome("Usuario teste")
+				.email("email123@gmail.com")
+				.senha("Senha123")
+				.funcaoId(1L)
+				.build();
+		RestAssured.given()
+				.port(port)
+				.contentType(ContentType.JSON)
+				.body(cadastrarUsuarioRequestDTO)
+				.log()
+				.all()
+				.when()
+				.post("/auth-service/v1/usuarios")
+				.then()
+				.statusCode(201);
+		ConfirmarCadastroUsuarioRequestDTO confirmarCadastroUsuarioRequestDTO = ConfirmarCadastroUsuarioRequestDTO.builder()
+				.email("email123@gmail.com")
+				.build();
+		var confirmarCadastroUsuarioResponseDto = RestAssured.given()
+				.port(port)
+				.contentType(ContentType.JSON)
+				.body(confirmarCadastroUsuarioRequestDTO)
+				.log()
+				.all()
+				.when()
+				.put("/auth-service/v1/usuarios/confirmar-cadastro")
+				.then()
+				.statusCode(200)
+				.extract()
+				.body()
+				.as(ConfirmarCadastroUsuarioResponseDTO.class);
+
+		assertTrue(confirmarCadastroUsuarioResponseDto.isConfirmado());
+	}
+
+	@Test
+	@DisplayName("Não deve confirmar o cadastro de um usuário inválido")
+	void naoDeveConfirmarCadastroUsuarioInvalido() {
+		ConfirmarCadastroUsuarioRequestDTO confirmarCadastroUsuarioRequestDTO = ConfirmarCadastroUsuarioRequestDTO.builder()
+				.email("email1234@gmail.com")
+				.build();
+		var errorMessage = RestAssured.given()
+				.port(port)
+				.contentType(ContentType.JSON)
+				.body(confirmarCadastroUsuarioRequestDTO)
+				.log()
+				.all()
+				.when()
+				.put("/auth-service/v1/usuarios/confirmar-cadastro")
+				.then()
+				.statusCode(400)
+				.extract()
+				.body()
+				.asString();
+
+		assertEquals("Usuário não encontrado.", errorMessage);
 	}
 
 }

--- a/src/test/resources/application-integration.properties
+++ b/src/test/resources/application-integration.properties
@@ -1,0 +1,28 @@
+# H2 Database Configuration
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Hibernate Configuration
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.hbm2ddl.import_files_sql_extractor=org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor
+
+# SQL Initialization
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:schema.sql
+spring.sql.init.data-locations=classpath:data.sql
+spring.sql.init.continue-on-error=true
+
+# Logging
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+# E-mail sender configuration
+auth-email-sender=inventario.fatec.mc@demomailtrap.co
+mail-trap-token=f0227568df4b5dd876b410a77e422192
+confirm-email-code-url=www.google.com
+confirm-template-id=4b58e1c5-58d2-4d04-84d2-0a9d8fabda85

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS usuario (
     nome VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL,
     senha VARCHAR(255) NOT NULL,
+    ativo BOOLEAN,
     data_criacao TIMESTAMP,
     data_alteracao TIMESTAMP,
     CONSTRAINT uk_usuario_email UNIQUE (email)


### PR DESCRIPTION
## Descrição

Adiciona funcionalidade de envio de e-mail de confirmação de cadastro de usuário. Além disso, adiciona também endpoint para confirmação de cadastro.

## Cobertura de testes local

<img width="622" height="155" alt="auth_02" src="https://github.com/user-attachments/assets/f63b5f35-cbc4-4980-834a-9e7c67d8ef25" />
